### PR TITLE
Replace CTO-Board with developer council

### DIFF
--- a/documentation/C-Sharp Coding Guidelines.tex
+++ b/documentation/C-Sharp Coding Guidelines.tex
@@ -26,7 +26,7 @@
 
 \begin{document}
 \title{Messerli C\# Coding Guideline}
-\author{CTO Board}
+\author{Developer council}
 \date{\today\\Version 1.0}
 \maketitle
 
@@ -48,7 +48,7 @@ Changes necessary due to the coding guidelines should be in a reasonable ratio t
 
 \subsection{Update to the rules and glossary}
 
-Updates to the rules and glossary should be sent to the CTO-Board. The CTO-Board will integrate new rules or new words in the glossary in a timely fashion when the board approves and will give feedback otherwise.
+Updates to the rules and glossary should be sent to the developer council. The developer council will integrate new rules or new words in the glossary in a timely fashion when the board approves and will give feedback otherwise.
 
 \subsection{Definition of done}
 

--- a/documentation/C-Sharp Coding Guidelines.tex
+++ b/documentation/C-Sharp Coding Guidelines.tex
@@ -37,7 +37,7 @@
 \section{Messerli C\# coding guidelines}
 
 These are the revised Coding Guidelines valid for code newly written in C\#.
-If you see mistakes or have, comments do not hesitate in contacting the CTO-Board.
+If you see mistakes or have, comments do not hesitate in contacting the developer council.
 
 \subsection{When and where are these rules applicable}
 


### PR DESCRIPTION
The CTO-Board was replaced by the developer council mid 2019